### PR TITLE
0.8.11

### DIFF
--- a/lib/weboverlay.ts
+++ b/lib/weboverlay.ts
@@ -67,7 +67,7 @@ export function weboverlay(options: WebOverlayOptions): express.Express {
      * Access logging
      */
 
-    app.use(morgan(log || "tiny", morganOptions));
+    app.use(morgan(log || "tiny", morganOptions) as RequestHandler);
 
     /**
      * Basic authentication
@@ -238,7 +238,7 @@ export function weboverlay(options: WebOverlayOptions): express.Express {
     // apply cache and decompression before first upstream connection
     function beforeUpstream() {
         if (cache) {
-            const cacheDir = cache.replace(/[^\.\/]+\/\.\.\//g, "") || ".";
+            const cacheDir = cache.replace(/[^\/]+\/\.\.\//g, "") || ".";
             logger.log("cache: " + cacheDir);
             app.use(express.static(cacheDir));
             app.use(tee(cacheDir, teeOptions));

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
   },
   "devDependencies": {
     "@types/express": "^4.17.13",
+    "@types/express-serve-static-core": "^4.17.25",
     "@types/mocha": "^9.0.0",
     "@types/morgan": "^1.9.3",
     "@types/node": "^16.11.10",

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
   ],
   "dependencies": {
     "express": "^4.17.1",
-    "express-charset": "^0.1.0",
+    "express-charset": "^0.1.1",
     "express-compress": "^0.8.0",
     "express-intercept": "^0.8.9",
     "express-sed": "^0.8.3",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "weboverlay",
   "description": "Layered Hybrid Web Server: local files, upstream proxy and content transform",
-  "version": "0.8.10",
+  "version": "0.8.11",
   "author": "Yusuke Kawasaki <u-suke@kawa.net>",
   "bin": {
     "weboverlay": "bin/weboverlay.cli.js"
@@ -27,12 +27,12 @@
     "@types/express": "^4.17.13",
     "@types/mocha": "^9.0.0",
     "@types/morgan": "^1.9.3",
-    "@types/node": "^16.9.1",
+    "@types/node": "^16.11.10",
     "@types/serve-index": "^1.9.1",
     "@types/supertest": "^2.0.11",
-    "mocha": "^9.1.1",
+    "mocha": "^9.1.3",
     "supertest": "^6.1.6",
-    "typescript": "^4.4.3"
+    "typescript": "^4.5.2"
   },
   "files": [
     "LICENSE",

--- a/test/auth.ts
+++ b/test/auth.ts
@@ -12,7 +12,9 @@ const TITLE = __filename.split("/").pop();
 describe(TITLE, () => {
     const options: WebOverlayOptions = {
         basic: [
+            // echo -n 'test1:first' | base64
             "test1:first", // "dGVzdDE6Zmlyc3Q="
+            // echo -n 'test2:second' | base64
             "dGVzdDI6c2Vjb25k" // "test2:second"
         ],
         layers: [

--- a/test/htdocs/charset/shift_jis/shift_jis.xml
+++ b/test/htdocs/charset/shift_jis/shift_jis.xml
@@ -1,3 +1,2 @@
 <?xml version="1.0" encoding="Shift_JIS" ?>
 <data>０１２３４５６７８９</data>
-

--- a/test/htdocs/sample.css
+++ b/test/htdocs/sample.css
@@ -1,6 +1,6 @@
 /* Hello, weboverlay! */
 /* sample.css */
 
-.body {
+body {
     background: white;
 }

--- a/test/upstream.ts
+++ b/test/upstream.ts
@@ -2,6 +2,7 @@
 
 import {strict as assert} from "assert";
 import * as express from "express";
+import {RequestHandler} from "express";
 import * as morgan from "morgan";
 import * as net from "net";
 import * as supertest from "supertest";
@@ -16,7 +17,7 @@ describe(TITLE, () => {
 
     before(async () => {
         const upstream = express();
-        upstream.use(morgan("tiny"));
+        upstream.use(morgan("tiny") as RequestHandler);
         const server = upstream.listen(0);
         onEnd = () => server.close();
         port = (server.address() as net.AddressInfo).port;

--- a/test/xml-charset.ts
+++ b/test/xml-charset.ts
@@ -9,7 +9,7 @@ import {weboverlay} from "../";
 const TITLE = __filename.split("/").pop();
 
 // assert.match
-const assert_match = ((str: string, re: RegExp): void => {
+const assert_match = assert.match || ((str: string, re: RegExp): void => {
     assert.ok(re.test(str), JSON.stringify({expected: re.source, actual: str}));
 });
 


### PR DESCRIPTION
weboverlay 0.8.10 has a bug with larger contents without line breaks when detecting charset.
i.e. minified huge css files.
express-charset 0.1.1 solves this.